### PR TITLE
OCAG-789 – Fix typos, broken link, and expand configuration-settings …

### DIFF
--- a/docs/configuration/configuration-settings.md
+++ b/docs/configuration/configuration-settings.md
@@ -2,3 +2,25 @@
 
 The configuration program includes two pages for configuring the LSAM and the LMAM.
 
+## [Configuration Settings (Page 1)](page-one-settings)
+
+Page one covers the core identity and connectivity settings the LSAM uses to communicate with OpCon/xps and the host:
+
+- RSI User-ID and default User-ID/Account for ST keyins
+- TSU process name, password, and LSAM system qualifier
+- Host machine name and maximum concurrent jobs
+- Console keyin, port number, and job start failure handling
+- ECL location display and end-of-job ECL modifications
+- Advanced Options, MASS configuration, IPv6, and TLS network security
+
+## [Configuration Settings (Page 2)](page-two-settings)
+
+Page two (reached via option 12 on page one) covers runtime behavior, debugging, and security options:
+
+- Start command display, CONS command use, and automated security responses
+- @@CONS RC timing, console message display level, and EXEC response position
+- OpCon job number usage, comma substitution, and SMAMSC connector
+- SKDPRG read key, European date format, debug mode, and check sum calculation
+- Alternate qualifier for tracking files, Mapper Machine, and authorized IP list
+- Job Output Retrieval System (JORS) configuration, authorized users, and inactivity timeout
+

--- a/docs/configuration/page-one-settings.md
+++ b/docs/configuration/page-one-settings.md
@@ -261,7 +261,7 @@ Yes (Y)
 
 ## Configure Console Keyin
 
-Item eight on page one of the configuration contains the console keyins for the LSAM and for XFRTCP (refer to [OS 2200 LSAM and BIS LMAM Configuration](configuration-settings).
+Item eight on page one of the configuration contains the console keyins for the LSAM and for XFRTCP (refer to [OS 2200 LSAM and BIS LMAM Configuration](configuration-settings)).
 
 1. For the Enter new console KEYIN for this LSAM (max 8 chars) prompt, enter the desired keyword for the LSAM.
 

--- a/docs/installation/preparing-the-installation.md
+++ b/docs/installation/preparing-the-installation.md
@@ -4,7 +4,7 @@ Complete these prerequisites before proceeding with either a [New Installation](
 
 ## System Parameters
 
-### File Qualifer
+### File Qualifier
 
 LSAM files must be referenced with an assigned file qualifier. SMA recommends using the standard qualifier "LSAM".
 

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -1,6 +1,6 @@
 # Known Issues
 
-## Use of @FREEM na @FREEALL in ECL
+## Use of @FREEM and @FREEALL in ECL
 
 The use of @FREEM and @FREEALL is not recommended in LSAM started jobs. These commands release all files from the run, including the tracking file monitored by the LSAM to determine when a job error terminates without executing the LSAM Notification Step. 
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -21,6 +21,6 @@ with the OpCon JobID, allowing for more than 32 concurrent instances
 - TCP/IP improvements
   - Improved support for IPv6
   - Support for TLS in app, not just through the CPCOMM settings
-  - Fix for MSGPOOL filling up, resulting in last messages
+  - Fix for MSGPOOL filling up, resulting in lost messages
 - Various performance and stability improvements
 


### PR DESCRIPTION
- Close missing paren in LMAM Configuration link (page-one-settings.md)
- Fix "Qualifer" → "Qualifier" (preparing-the-installation.md)
- Fix "@FREEM na @FREEALL" → "and" (known-issues.md)
- Fix "last messages" → "lost messages" (release-notes.md)
- Add page 1 / page 2 links and settings overview to configuration-settings.md